### PR TITLE
Fixes an error in the examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,6 @@ $additionalParams = array(
     'filter_lang' => 'en',
     'filter' => '{"variable_name":"some","operator":"or","conditions":[{"condition":"likewith","value":"a"},{"condition":"notequal","value":"b"}]}',
 );
-var_dump($SPApiProxy->createPushTask($task, $additionalParams));
+var_dump($SPApiClient->createPushTask($task, $additionalParams));
 ```
 

--- a/example/index.php
+++ b/example/index.php
@@ -69,4 +69,4 @@ $additionalParams = array(
     'filter_lang' => 'en',
     'filter' => '{"variable_name":"some","operator":"or","conditions":[{"condition":"likewith","value":"a"},{"condition":"notequal","value":"b"}]}',
 );
-var_dump($SPApiProxy->createPushTask($task, $additionalParams));
+var_dump($SPApiClient->createPushTask($task, $additionalParams));


### PR DESCRIPTION
In the usage examples (readme and example file) the webpush task is created by invoking the createPushTask() method on a non existing variable.