### PR TITLE
Update ApiClient.php

### DIFF
--- a/src/ApiClient.php
+++ b/src/ApiClient.php
@@ -153,6 +153,7 @@ class ApiClient implements ApiInterface
             $this->getToken();
             $retval = $this->sendRequest($path, $method, $data);
         } else {
+            $this->refreshToken = 0;
             $retval = new stdClass();
             $retval->data = json_decode($responseBody);
             $retval->http_code = $headerCode;


### PR DESCRIPTION
$this->refreshToken должен быть сброшен при успешном запросе, т.к. при неуспешном он был увеличен на 1. Иначе второй раз токен не обновится.