### PR TITLE
Authentication fix, #37

### DIFF
--- a/src/ApiClient.php
+++ b/src/ApiClient.php
@@ -117,7 +117,7 @@ class ApiClient implements ApiInterface
         switch ($method) {
             case 'POST':
                 curl_setopt($curl, CURLOPT_POST, count($data));
-                curl_setopt($curl, CURLOPT_POSTFIELDS, http_build_query($data));
+                curl_setopt($curl, CURLOPT_POSTFIELDS, $data);
                 break;
             case 'PUT':
                 curl_setopt($curl, CURLOPT_CUSTOMREQUEST, 'PUT');


### PR DESCRIPTION
From https://www.php.net/manual/en/function.curl-setopt.php for CURLOPT_POSTFIELDS option:

> ... If value is an array, the Content-Type header will be set to multipart/form-data ...

That fix the issue #37 